### PR TITLE
Add owner/group for workspaces dir

### DIFF
--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -50,7 +50,7 @@
       dnf: name=gnome-tweak-tool state=latest
 
     - name: create code workspace
-      file:  path=/home/{{me}}/workspaces state=directory mode=0755
+      file:  path=/home/{{me}}/workspaces state=directory mode=0755 owner={{me}} group={{me}}
 
     - name: install google chrome
       dnf: name=https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm state=present


### PR DESCRIPTION
When running the playbook as root user (rather than using "become"), workspaces dir will belong to root/root.